### PR TITLE
DP: 스티커

### DIFF
--- a/backjoon/DP/스티커_9465.js
+++ b/backjoon/DP/스티커_9465.js
@@ -1,0 +1,48 @@
+/*
+백준 9465번 스티커
+https://www.acmicpc.net/problem/9465
+*/
+
+const [T, ...rest] = require("fs")
+  .readFileSync("example.txt")
+  .toString()
+  .trim()
+  .split("\n");
+
+const solution = (columnSize, stickerMatrix) => {
+  const row1 = stickerMatrix[0];
+  const row2 = stickerMatrix[1];
+  let [firstMaxValue, secondMaxValue] = [0, 0];
+  let [firstMaxIndex, secondMaxIndex] = [-1, -1];
+  for (let i = 0; i < columnSize; i++) {
+    [
+      [row1[i], i],
+      [row2[i], columnSize + i],
+    ]
+      .map(([value, index]) =>
+        index === 0 || index - 1 !== firstMaxIndex
+          ? [firstMaxValue + value, index]
+          : [secondMaxValue + value, index]
+      )
+      .forEach(([maxValue, index]) => {
+        if (maxValue > firstMaxValue) {
+          secondMaxValue = firstMaxValue;
+          secondMaxIndex = firstMaxIndex;
+          firstMaxValue = maxValue;
+          firstMaxIndex = index;
+        } else if (maxValue > secondMaxValue) {
+          secondMaxValue = maxValue;
+          secondMaxIndex = index;
+        }
+      });
+  }
+  console.log(firstMaxValue);
+};
+
+for (let i = 0; i < T; i++) {
+  const start = i * 3;
+  let [n, ...stickerMatrix] = rest.slice(start, start + 3);
+  n = Number(n);
+  stickerMatrix = stickerMatrix.map((row) => row.split(" ").map(Number));
+  solution(n, stickerMatrix);
+}


### PR DESCRIPTION
가장 큰수와 그의 index값과 2번쨰로 큰수와 그의 index값을 저장해가며 순회를 진행한다.
기본적으로 가장 큰수에 스티커 점수를 더하는게 가장 이득이지만, index - 1의 위치해있다면 더할 수 없다. 이경우에는 두번째로 큰 수를 더해준다.
순회가 끝난후 가장 큰 수를 출력한다.