### PR TITLE
그리디: 회의실 배정

### DIFF
--- a/backjoon/그리디/회의실_배정_1931.js
+++ b/backjoon/그리디/회의실_배정_1931.js
@@ -1,0 +1,35 @@
+/*
+백준 1931 회의실 배정
+https://www.acmicpc.net/problem/1931
+*/
+
+let [, ...meetingTimes] = require("fs")
+  .readFileSync("example.txt")
+  .toString()
+  .trim()
+  .split("\n");
+
+meetingTimes = meetingTimes.map((meetingTime) =>
+  meetingTime.split(" ").map(Number)
+);
+
+const solution = (meetingTimes) => {
+  meetingTimes.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  let totalMeetingCount = 0,
+    currStartTime = 0,
+    currEndTime = 0;
+  for (const [meetingStart, meetingEnd] of meetingTimes) {
+    if (currEndTime <= meetingStart) {
+      totalMeetingCount++;
+      currStartTime = meetingStart;
+      currEndTime = meetingEnd;
+    } else if (meetingEnd < currEndTime) {
+      currStartTime = meetingStart;
+      currEndTime = meetingEnd;
+    }
+  }
+
+  console.log(totalMeetingCount);
+};
+
+solution(meetingTimes);


### PR DESCRIPTION
배열을 오름차순 정렬한다 ( 우선순위, 시작시간 - 종료시간 순으로 )
배열을 순회하며 회의를 진행한다.
현재 진행중인 회의 종료시간보다 다음 회의 시작시간이 늦을경우, totalCount++ 후 회의를 교체한다.
현재 진행중인 회의 종료시간보다 다음 회의 종료시간이 이를경우, 회의를 교체한다.