### PR TITLE
스택/큐: 압축

### DIFF
--- a/backjoon/스택_큐/압축_1662.js
+++ b/backjoon/스택_큐/압축_1662.js
@@ -1,3 +1,8 @@
+/*
+백준 1662번 압축
+https://www.acmicpc.net/problem/1662
+*/
+
 const input = require("fs").readFileSync("example.txt").toString().trim();
 
 const solution = (string) => {

--- a/backjoon/스택_큐/압축_1662.js
+++ b/backjoon/스택_큐/압축_1662.js
@@ -1,0 +1,24 @@
+const input = require("fs").readFileSync("example.txt").toString().trim();
+
+const solution = (string) => {
+  const stack = [0];
+  for (let i = 0; i < string.length; i++) {
+    const char = string[i];
+    if (char === ")") {
+      const length = stack.pop();
+      const multiply = stack.pop();
+      stack[stack.length - 1] += multiply * length;
+      continue;
+    }
+    if (char === "(") {
+      stack[stack.length - 1]--;
+      stack.push(Number(string[i - 1]));
+      stack.push(0);
+      continue;
+    }
+    stack[stack.length - 1]++;
+  }
+  return stack.reduce((acc, element) => acc + element, 0);
+};
+
+console.log(solution(input));


### PR DESCRIPTION
Javascript가 표현할 수 있는 문자열의 길이 제한이 있기때문에 ( 그리고 메모리 관리를 위해)
문자열의 길이만을 stack에 담는다.
( 가 등장하면, 이전 숫자는 multiply 이므로, 증가시키던 stack의 top 숫자를 1 빼고, 해당 숫자만큼을 stack에 push 한다. 이후 새로운 length를 세기 위해 0을 push 한다.
) 가 등장하면, 하나를 pop 하여 length, 그 다음을 pop 하여 multiply가 되므로 그 둘을 곱하여 stack의 top에 + 한다.
완료 이후 stack의 모든 수를 sum 한다.