### PR TITLE
이분탐색: 입국심사

### DIFF
--- a/programmers/이분탐색/입국심사.js
+++ b/programmers/이분탐색/입국심사.js
@@ -1,0 +1,31 @@
+/*
+프로그래머스 / 이분탐색 / 입국심사
+https://programmers.co.kr/learn/courses/30/lessons/43238
+*/
+
+function solution(n, times) {
+  times.sort((a, b) => a - b);
+  const worstTime = Math.ceil(n / times.length) * times[times.length - 1];
+  const bestTime = Math.ceil(n / times.length) * times[0];
+  let leftTime = bestTime;
+  let rightTime = worstTime;
+  let minTime = rightTime;
+  while (leftTime < rightTime) {
+    const middleTime = Math.floor((rightTime + leftTime) / 2);
+    const totalJudged = times.reduce(
+      (totalJudged, time) => totalJudged + Math.floor(middleTime / time),
+      0
+    );
+    if (totalJudged < n) {
+      leftTime = middleTime + 1;
+      continue;
+    }
+    if (totalJudged >= n) {
+      minTime = middleTime;
+      rightTime = middleTime;
+      continue;
+    }
+  }
+
+  return minTime;
+}


### PR DESCRIPTION
심사받는 인원이 최대 10억이므로, 해당 횟수만큼 순회를 돌면 시간 초과가 나게된다.
그러므로 정해진 시간동안, 심사할수 있는 인원이 n 이상인지를 판단함으로서 n 이상인 시간중 최소인 시간을 구한다.
최악으로 오래걸리는 경우는 가장 느린 심사위원의 속도로 모든 심사위원이 심사를 할경우,
최선으로 오래걸리는 경우는 가장 빠른 심사위원의 속도로 모든 심사위원이 심사를 할경우이다.
해당 두 시간을 기점으로 이분탐색을 통해 최적의 시간을 찾는다.