### PR TITLE
이진탐색: 꼬인 전깃줄

### DIFF
--- a/backjoon/이진탐색/꼬인_전깃줄_1365.js
+++ b/backjoon/이진탐색/꼬인_전깃줄_1365.js
@@ -1,0 +1,47 @@
+const [NStr, polesStr] = require("fs")
+  .readFileSync("example.txt")
+  .toString()
+  .trim()
+  .split("\n");
+
+const N = Number(NStr);
+const poles = polesStr.split(" ").map(Number);
+
+const solution = (N, poles) => {
+  const longestIncreaseSubset = _getLIS(poles, N);
+  const answer = N - longestIncreaseSubset;
+
+  console.log(answer);
+
+  function _getLIS(array, N) {
+    const memo = [array[0]];
+
+    for (let i = 1; i < N; i++) {
+      const curr = array[i];
+      if (curr > memo[memo.length - 1]) memo.push(curr);
+      else {
+        const leastIncrease = _lowerBound(memo, curr);
+        memo[leastIncrease] = curr;
+      }
+    }
+
+    return memo.length;
+  }
+
+  function _lowerBound(array, key) {
+    let left = 0;
+    let right = array.length - 1;
+
+    while (left < right) {
+      const mid = Math.floor((left + right) / 2);
+      if (array[mid] < key) {
+        left = mid + 1;
+      } else {
+        right = mid;
+      }
+    }
+    return left;
+  }
+};
+
+solution(N, poles);


### PR DESCRIPTION
가장 긴 증가하는 부분수열과 같다.
그걸 깨닫는데 까지 시간이 꽤나 걸렸다.
초점을 두어야 할것은, 어떨때, 선이 꼬이지 않느냐이다.
선이 꼬이지 않으려면, 연결되는 선이 계속해서 증가해야한다.
결국 가장 적은 수의 전기줄을 끊으려면,
전기줄들의 서브셋중, 가장 많이 연결된 전기줄의 개수를 구한다. 즉, 가장 긴 증가하는 부분수열의 길이를 구하면 된다.